### PR TITLE
Remove unneeded 'add_pem_header' function

### DIFF
--- a/pywarp/attestation.py
+++ b/pywarp/attestation.py
@@ -7,7 +7,6 @@ from cryptography.hazmat.primitives.asymmetric import ec, padding
 
 from .cose import COSE
 from .fido.metadata import FIDOMetadataClient
-from .util import add_pem_header
 
 class AttestationStatement:
     validated_attestation = namedtuple("ValidatedAttestation", "type trust_path credential")
@@ -45,7 +44,7 @@ class FIDOU2FAttestationStatement(AttestationStatement, FIDOMetadataClient):
         # See https://github.com/pyca/cryptography/issues/2381
         # See https://github.com/wbond/certvalidator
         assert len(att_root_cert_chain) == 1
-        att_root_cert = x509.load_pem_x509_certificate(add_pem_header(att_root_cert_chain[0]).encode(),
+        att_root_cert = x509.load_der_x509_certificate(att_root_cert_chain[0].encode(),
                                                        cryptography.hazmat.backends.default_backend())
         att_root_cert.public_key().verify(self.att_cert.signature,
                                           self.att_cert.tbs_certificate_bytes,

--- a/pywarp/fido/metadata.py
+++ b/pywarp/fido/metadata.py
@@ -5,8 +5,6 @@ import cryptography.hazmat.backends
 from cryptography import x509
 import jwt
 
-from ..util import add_pem_header
-
 try:
     from botocore.vendored import requests
 except ImportError:
@@ -23,7 +21,7 @@ class FIDOMetadataClient:
             res.raise_for_status()
             jwt_header = jwt.get_unverified_header(res.content)
             assert jwt_header["alg"] == "ES256"
-            cert = x509.load_pem_x509_certificate(add_pem_header(jwt_header["x5c"][0]).encode(),
+            cert = x509.load_der_x509_certificate(jwt_header["x5c"][0].encode(),
                                                   cryptography.hazmat.backends.default_backend())
             self._metadata_toc = jwt.decode(res.content, key=cert.public_key(), algorithms=["ES256"])
         return self._metadata_toc

--- a/pywarp/util/__init__.py
+++ b/pywarp/util/__init__.py
@@ -1,8 +1,5 @@
 import textwrap, base64
 
-PEM_HEADER = "-----BEGIN CERTIFICATE-----"
-PEM_FOOTER = "-----END CERTIFICATE-----"
-
 def b64_encode(b):
     return base64.b64encode(b).decode()
 
@@ -17,9 +14,6 @@ def b64url_decode(s):
 
 def b64_restore_padding(unpadded_b64_string):
     return unpadded_b64_string + '=' * (-len(unpadded_b64_string) % 4)
-
-def add_pem_header(bare_base64_cert):
-    return PEM_HEADER + "\n" + textwrap.fill(bare_base64_cert, 64) + "\n" + PEM_FOOTER
 
 class Placeholder:
     """


### PR DESCRIPTION
cryptography can parse DER certificates directly, no need to wrap in PEM header/footer