### PR TITLE
Update PyJWT dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 
 python:
-  - 3.4
-  - 3.5
   - 3.6
+  - 3.7
+  - 3.8
+  - 3.9
 
 before_install:
   - pip install --quiet --upgrade pip codecov

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,8 @@ Installation
 
     pip install pywarp
 
+PyWARP requires Python 3.6+. Python 2.7 and <= 3.5 is not supported.
+
 PyWARP depends on `cryptography <https://github.com/pyca/cryptography>`_, which in turn requires OpenSSL and CFFI. See
 the `cryptography installation docs <https://cryptography.io/en/latest/installation/>`_ for more details.
 

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,6 @@ Installation
 
     pip install pywarp
 
-PyWARP requires Python 3.4+. Python 2.7 is not supported.
-
 PyWARP depends on `cryptography <https://github.com/pyca/cryptography>`_, which in turn requires OpenSSL and CFFI. See
 the `cryptography installation docs <https://cryptography.io/en/latest/installation/>`_ for more details.
 

--- a/examples/chalice/requirements.txt
+++ b/examples/chalice/requirements.txt
@@ -1,4 +1,4 @@
-pyjwt >= 1.5.3, < 2
+pyjwt >= 2.0.1
 cbor2 >= 4.1.2, < 5
 cryptography >= 3.2, < 4
 pynamodb >= 3.3.1, < 4

--- a/pywarp/rp.py
+++ b/pywarp/rp.py
@@ -1,4 +1,4 @@
-import re, json, hashlib
+import re, json, hashlib, secrets
 
 import cbor2
 
@@ -6,7 +6,6 @@ from .attestation import FIDOU2FAttestationStatement
 from .authenticators import AuthenticatorData
 from .cose import Algorithms
 from .util import b64_encode, b64url_decode
-from .util.compat import token_bytes
 
 
 class RelyingPartyManager:
@@ -17,7 +16,7 @@ class RelyingPartyManager:
 
     def get_registration_options(self, email, display_name=None, icon=None):
         "Get challenge parameters that will be passed to the user agent's navigator.credentials.get() method"
-        challenge = token_bytes(32)
+        challenge = secrets.token_bytes(32)
 
         options = {
             "challenge": b64_encode(challenge),
@@ -47,7 +46,7 @@ class RelyingPartyManager:
 
     def get_authentication_options(self, email):
         credential = self.storage_backend.get_credential_by_email(email)
-        challenge = token_bytes(32)
+        challenge = secrets.token_bytes(32)
 
         options = {
             "challenge": challenge,

--- a/pywarp/util/compat.py
+++ b/pywarp/util/compat.py
@@ -1,4 +1,0 @@
-try:
-    from secrets import token_bytes
-except ImportError:
-    from os import urandom as token_bytes

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description="Python WebAuthn Relying Party library",
     long_description=open("README.rst").read(),
     install_requires=[
-        "pyjwt >= 1.5.3, < 2",
+        "pyjwt >= 2.0.1",
         "cbor2 >= 4.1.2, < 5",
         "cryptography >= 3.2, < 4",
         "requests >= 2.18.4, < 3"


### PR DESCRIPTION
This break the execution of pywarp on Python 3.5, because PyJWT drop it. However, Python 3.5 is EOL.

Thus, the real question behind this PR is "Would you drop EOL versions of python?"

Thanks